### PR TITLE
Fix database defaults and artist creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ npm run dev
 ```
 This command starts `src/server.js` via nodemon and serves the REST endpoints on the configured port.
 
+Create a `.env` file inside `music-library-api` with your connection details:
+
+```
+MONGO_URI=mongodb://localhost:27017/musiclibrary
+JWT_SECRET=your-secret
+```
+`MONGO_URI` is optional. When omitted, the API defaults to `mongodb://localhost:27017/musiclibrary`.
+
 ### Frontend configuration
 
 Create a `.env` file inside `music-library-frontend` and specify your API URL:

--- a/music-library-api/src/config/db.js
+++ b/music-library-api/src/config/db.js
@@ -3,7 +3,8 @@ const mongoose = require('mongoose');
 
 const connectDB = async() => {
     try {
-        await mongoose.connect(process.env.MONGO_URI);
+        const uri = process.env.MONGO_URI || 'mongodb://localhost:27017/musiclibrary';
+        await mongoose.connect(uri);
         console.log('MongoDB Connected...');
     } catch (err) {
         console.error(err.message);

--- a/music-library-api/src/controllers/artistController.js
+++ b/music-library-api/src/controllers/artistController.js
@@ -1,4 +1,5 @@
 const Artist = require('../models/Artist');
+const { v4: uuidv4 } = require('uuid');
 
 exports.getArtists = async(req, res) => {
     try {
@@ -12,7 +13,7 @@ exports.getArtists = async(req, res) => {
 exports.createArtist = async(req, res) => {
     try {
         const { name } = req.body;
-        const newArtist = new Artist({ name });
+        const newArtist = new Artist({ artist_id: uuidv4(), name });
         await newArtist.save();
         res.json(newArtist);
     } catch (err) {


### PR DESCRIPTION
## Summary
- assign unique ID when creating artists
- allow fallback MongoDB URI when `.env` is missing
- document optional `.env` file setup

## Testing
- `node music-library-api/src/server.js`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9ba4e5ec832db7e8a4dd4b376cce