### PR TITLE
Add signup feature and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@ N: Node.js is an open-source server environment that runs on multiple operating 
 These technologies work together to create single-page web apps that are quickly loaded, perform well, and provide seamless user experiences.
 Windows, Linux, Unix, macOS, and more...
 
-
 ## Project Objectives
 
 Developed a RESTful API that allows users to manage their music library.
-Created a Music Library Management API in order to manage the artists, tracks, and albums in an organization's library. 
+Created a Music Library Management API in order to manage the artists, tracks, and albums in an organization's library.
 One administrator is in charge of the system and its users for each organization.
 Users can also mark their favorite artists, albums, and tracks for easy access and customization via the API.
-
 
 
 The following directories are present in the project directory:
@@ -28,7 +26,6 @@ The following directories are present in the project directory:
 - **music-library-frontend**: This directory contains the React.js-built client-side source code for the admin interface.
 -  This includes the React.js-built client interface's client-side source code.
 - **music-library-api**: Contains the Node.js and Express.js server-side source code.
-
 
 ## How to Use
 
@@ -53,6 +50,33 @@ REACT_APP_API_URL=https://api.example.com/api
 
 The React app falls back to `http://localhost:5000/api` when this variable is not set.
 
+## Running the Project
+
+Open two terminals and run the following commands:
+
+**Backend**
+```
+cd music-library-api
+node src/server.js
+```
+
+**Frontend**
+```
+cd music-library-frontend
+npm install
+npm start
+```
+The frontend will be served on `http://localhost:3000`.
+
+### Signup & Login
+
+Use the Signup page to create an account and then log in with your credentials. Tokens are stored in localStorage after successful login.
+
+### Deployment on Vercel
+
+1. Install the [Vercel CLI](https://vercel.com/docs/cli) and run `vercel` inside `music-library-frontend`.
+2. Set the `REACT_APP_API_URL` environment variable when prompted so the frontend can reach the API.
+3. After deployment, Vercel will provide a URL where your React application is hosted.
 
 ## Principal Technology
 
@@ -60,8 +84,6 @@ The React app falls back to `http://localhost:5000/api` when this variable is no
 **Package and Tool Management**: npm, Git
 **Front-end**: React.js, HTML, CSS, JavaScript
 **Security Middleware**: Helmet (recommended)
-
-
 
 ## Author
 - **Name**: Vinod M

--- a/music-library-api/src/routes/authRoutes.js
+++ b/music-library-api/src/routes/authRoutes.js
@@ -1,18 +1,11 @@
 const express = require('express');
+const { signup, login } = require('../controllers/authController');
 const router = express.Router();
-const jwt = require('jsonwebtoken');
 
-router.post('/login', async(req, res) => {
-    const { username, password } = req.body;
+// Register a new user
+router.post('/signup', signup);
 
-    // Replace this with your actual user authentication logic
-    if (username === 'admin' && password === 'password') {
-        const payload = { user: { id: 'adminId' } };
-        const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
-        return res.json({ token });
-    }
-
-    res.status(401).json({ msg: 'Invalid credentials' });
-});
+// Authenticate user and return token
+router.post('/login', login);
 
 module.exports = router;

--- a/music-library-frontend/src/App.js
+++ b/music-library-frontend/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import Home from './pages/Home';
 import Login from './pages/Login';
+import Signup from './pages/Signup';
 
 const App = () => (
   <Router>
@@ -10,6 +11,7 @@ const App = () => (
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/login" element={<Login />} />
+      <Route path="/signup" element={<Signup />} />
     </Routes>
   </Router>
 );

--- a/music-library-frontend/src/api.js
+++ b/music-library-frontend/src/api.js
@@ -7,5 +7,7 @@ const API = axios.create({
 export const fetchArtists = () => API.get('/artists');
 export const fetchAlbums = () => API.get('/albums');
 export const fetchTracks = () => API.get('/tracks');
+export const signup = (email, password) => API.post('/auth/signup', { email, password });
+export const login = (email, password) => API.post('/auth/login', { email, password });
 
 export default API;

--- a/music-library-frontend/src/components/Navbar.js
+++ b/music-library-frontend/src/components/Navbar.js
@@ -1,8 +1,14 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const Navbar = () => (
   <nav>
     <h1>Music Library</h1>
+    <ul>
+      <li><Link to="/">Home</Link></li>
+      <li><Link to="/login">Login</Link></li>
+      <li><Link to="/signup">Signup</Link></li>
+    </ul>
   </nav>
 );
 

--- a/music-library-frontend/src/pages/Signup.js
+++ b/music-library-frontend/src/pages/Signup.js
@@ -1,24 +1,23 @@
 import React, { useState } from 'react';
-import { login } from '../api';
+import { signup } from '../api';
 
-const Login = () => {
+const Signup = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
 
-  const handleLogin = async () => {
+  const handleSignup = async () => {
     try {
-      const { data } = await login(email, password);
-      localStorage.setItem('token', data.token);
-      setMessage('Login successful');
+      await signup(email, password);
+      setMessage('Signup successful');
     } catch (error) {
-      setMessage('Invalid credentials');
+      setMessage('Error creating account');
     }
   };
 
   return (
     <div>
-      <h2>Login</h2>
+      <h2>Signup</h2>
       <input
         type="email"
         placeholder="Email"
@@ -31,10 +30,10 @@ const Login = () => {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
-      <button onClick={handleLogin}>Login</button>
+      <button onClick={handleSignup}>Signup</button>
       {message && <p>{message}</p>}
     </div>
   );
 };
 
-export default Login;
+export default Signup;


### PR DESCRIPTION
## Summary
- create API routes for signup and login
- add signup and login pages on the frontend
- expose signup and login functions in api helper
- expand navbar with links
- document running project and deploying to Vercel

## Testing
- `node src/server.js` *(fails: ENOTFOUND _mongodb._tcp.cluster0.vrmotev.mongodb.net\database_name)*
- `CI=true npm test --silent` in music-library-frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9ca3892c832d9ee8826d6256a613